### PR TITLE
Add --checkout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,6 @@ You can then merge these changes into your existing code:
 This code is heavily based on https://github.com/aroig/cookiecutter-latex-paper/blob/master/make/cookiecutter-update.py, with a few very small changes. 
 
 Note that you will need a recent version of git for this to work (it needs --no-checkout on git worktree)
+
+Use `--checkout REV` or `-c REV` to check out a specific template revision. This option is forwarded to cookiecutter, and takes a branch, tag, or commit which should be checked out by cookiecutter after cloning the template repository.
+

--- a/cupper.py
+++ b/cupper.py
@@ -34,7 +34,7 @@ class TemporaryWorkdir():
         subprocess.run(["git", "worktree", "prune"], cwd=self.repo)
 
 
-def update_template(context, root, branch):
+def update_template(context, root, branch, checkout=None):
     """Update template branch from a template url"""
     template_url = context['_template']
     tmpdir       = os.path.join(root, ".git", "cookiecutter")
@@ -53,6 +53,7 @@ def update_template(context, root, branch):
     with TemporaryWorkdir(tmp_workdir, repo=root, branch=branch):
         # update the template
         cookiecutter(template_url,
+                     checkout=checkout,
                      no_input=True,
                      extra_context=context,
                      overwrite_if_exists=True,
@@ -67,8 +68,9 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("context_file", metavar="context-file")
     parser.add_argument("branch")
+    parser.add_argument("--checkout", "-c")
     args = parser.parse_args()
     with open(args.context_file, 'r') as fd:
         context = json.load(fd)
 
-    update_template(context, os.getcwd(), branch=args.branch)
+    update_template(context, os.getcwd(), branch=args.branch, checkout=args.checkout)

--- a/cupper.py
+++ b/cupper.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import argparse
 import os
 import sys
 import json
@@ -63,12 +64,11 @@ def update_template(context, root, branch):
                        cwd=tmp_workdir)
 
 def main():
-    import sys
-    if len(sys.argv) != 3:
-        print("Usage: cupper <context filename> <branch>")
-        sys.exit(1)
-    context_file, branch = sys.argv[1], sys.argv[2]
-    with open(context_file, 'r') as fd:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("context_file", metavar="context-file")
+    parser.add_argument("branch")
+    args = parser.parse_args()
+    with open(args.context_file, 'r') as fd:
         context = json.load(fd)
 
-    update_template(context, os.getcwd(), branch=branch)
+    update_template(context, os.getcwd(), branch=args.branch)

--- a/cupper.py
+++ b/cupper.py
@@ -68,7 +68,9 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("context_file", metavar="context-file")
     parser.add_argument("branch")
-    parser.add_argument("--checkout", "-c")
+    parser.add_argument(
+        "--checkout", "-c", metavar="REV", help="check out the given template revision"
+    )
     args = parser.parse_args()
     with open(args.context_file, 'r') as fd:
         context = json.load(fd)

--- a/cupper.py
+++ b/cupper.py
@@ -66,8 +66,12 @@ def update_template(context, root, branch, checkout=None):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("context_file", metavar="context-file")
-    parser.add_argument("branch")
+    parser.add_argument(
+        "context_file",
+        metavar="context-file",
+        help="JSON file containing configuration for cookiecutter",
+    )
+    parser.add_argument("branch", help="name of the branch to create")
     parser.add_argument(
         "--checkout", "-c", metavar="REV", help="check out the given template revision"
     )


### PR DESCRIPTION
First off, thank you for this useful tool!

Would you consider accepting this PR, which makes Cookiecutter's `--checkout` option available via cupper?

Currently cupper always fetches the latest version from the master branch. This option allows to fetch a tagged release instead. Example:

```console
$ cupper --checkout=v1.0.0 .cookiecutter.json cookiecutter
```

The PR also uses the standard `argparse` library, changing the usage message to the following:

```console
usage: cupper [-h] [--checkout REV] context-file branch

positional arguments:
  context-file          JSON file containing configuration for cookiecutter
  branch                name of the branch to create

optional arguments:
  -h, --help            show this help message and exit
  --checkout REV, -c REV
                        check out the given template revision
```