### PR TITLE
Run commit without pre-commit hooks (--no-verify)

### DIFF
--- a/cupper.py
+++ b/cupper.py
@@ -42,8 +42,8 @@ def update_template(context, root, branch):
 
     context['project_slug'] = project_slug
     # create a template branch if necessary
-    if subprocess.check_call(["git", "rev-parse", "-q", "--verify", branch], cwd=root).returncode != 0:
-        firstref = subprocess.run(["git", "rev-list", "--max-parents=0", "--max-count=1", "HEAD"],
+    if subprocess.run(["git", "rev-parse", "-q", "--verify", branch], cwd=root).returncode != 0:
+        firstref = subprocess.check_call(["git", "rev-list", "--max-parents=0", "--max-count=1", "HEAD"],
                                   cwd=root,
                                   stdout=subprocess.PIPE,
                                   universal_newlines=True).stdout.strip()

--- a/cupper.py
+++ b/cupper.py
@@ -45,7 +45,6 @@ def update_template(context, root, branch):
     if subprocess.run(["git", "rev-parse", "-q", "--verify", branch], cwd=root).returncode != 0:
         firstref = subprocess.check_output(["git", "rev-list", "--max-parents=0", "--max-count=1", "HEAD"],
                                            cwd=root,
-                                           stdout=subprocess.PIPE,
                                            universal_newlines=True).strip()
         subprocess.check_call(["git", "branch", branch, firstref])
 
@@ -59,8 +58,10 @@ def update_template(context, root, branch):
 
         # commit to template branch
         subprocess.check_call(["git", "add", "-A", "."], cwd=tmp_workdir)
-        subprocess.check_call(["git", "commit", "-nm", "Update template"],
-                              cwd=tmp_workdir)
+        if b'nothing to commit' not in subprocess.check_output(["git", "status"],
+                                                              cwd=tmp_workdir):
+            subprocess.check_call(["git", "commit", "-nm", "Update template"],
+                                  cwd=tmp_workdir)
 
 def main():
     import sys

--- a/cupper.py
+++ b/cupper.py
@@ -59,7 +59,7 @@ def update_template(context, root, branch):
 
         # commit to template branch
         subprocess.run(["git", "add", "-A", "."], cwd=tmp_workdir)
-        subprocess.run(["git", "commit", "-m", "Update template"],
+        subprocess.run(["git", "commit", "-nm", "Update template"],
                        cwd=tmp_workdir)
 
 def main():

--- a/cupper.py
+++ b/cupper.py
@@ -25,7 +25,7 @@ class TemporaryWorkdir():
             raise Exception("Temporary directory already exists: %s" % self.path)
 
         os.makedirs(self.path)
-        subprocess.check_call(["git", "worktree",  "add", "--no-checkout", self.path, self.branch],
+        subprocess.check_call(["git", "worktree", "add", "--no-checkout", self.path, self.branch],
                               cwd=self.repo)
 
     def __exit__(self, type, value, traceback):

--- a/cupper.py
+++ b/cupper.py
@@ -26,7 +26,7 @@ class TemporaryWorkdir():
 
         os.makedirs(self.path)
         subprocess.check_call(["git", "worktree",  "add", "--no-checkout", self.path, self.branch],
-                       cwd=self.repo)
+                              cwd=self.repo)
 
     def __exit__(self, type, value, traceback):
         shutil.rmtree(self.path)
@@ -43,10 +43,10 @@ def update_template(context, root, branch):
     context['project_slug'] = project_slug
     # create a template branch if necessary
     if subprocess.run(["git", "rev-parse", "-q", "--verify", branch], cwd=root).returncode != 0:
-        firstref = subprocess.check_call(["git", "rev-list", "--max-parents=0", "--max-count=1", "HEAD"],
-                                  cwd=root,
-                                  stdout=subprocess.PIPE,
-                                  universal_newlines=True).stdout.strip()
+        firstref = subprocess.check_output(["git", "rev-list", "--max-parents=0", "--max-count=1", "HEAD"],
+                                           cwd=root,
+                                           stdout=subprocess.PIPE,
+                                           universal_newlines=True).strip()
         subprocess.check_call(["git", "branch", branch, firstref])
 
     with TemporaryWorkdir(tmp_workdir, repo=root, branch=branch):
@@ -60,7 +60,7 @@ def update_template(context, root, branch):
         # commit to template branch
         subprocess.check_call(["git", "add", "-A", "."], cwd=tmp_workdir)
         subprocess.check_call(["git", "commit", "-nm", "Update template"],
-                       cwd=tmp_workdir)
+                              cwd=tmp_workdir)
 
 def main():
     import sys

--- a/cupper.py
+++ b/cupper.py
@@ -58,8 +58,8 @@ def update_template(context, root, branch):
 
         # commit to template branch
         subprocess.check_call(["git", "add", "-A", "."], cwd=tmp_workdir)
-        if b'nothing to commit' not in subprocess.check_output(["git", "status"],
-                                                              cwd=tmp_workdir):
+        if b"nothing to commit" not in subprocess.check_output(["git", "status"],
+                                                               cwd=tmp_workdir):
             subprocess.check_call(["git", "commit", "-nm", "Update template"],
                                   cwd=tmp_workdir)
 

--- a/cupper.py
+++ b/cupper.py
@@ -25,12 +25,12 @@ class TemporaryWorkdir():
             raise Exception("Temporary directory already exists: %s" % self.path)
 
         os.makedirs(self.path)
-        subprocess.run(["git", "worktree",  "add", "--no-checkout", self.path, self.branch],
+        subprocess.check_call(["git", "worktree",  "add", "--no-checkout", self.path, self.branch],
                        cwd=self.repo)
 
     def __exit__(self, type, value, traceback):
         shutil.rmtree(self.path)
-        subprocess.run(["git", "worktree", "prune"], cwd=self.repo)
+        subprocess.check_call(["git", "worktree", "prune"], cwd=self.repo)
 
 
 def update_template(context, root, branch):
@@ -42,12 +42,12 @@ def update_template(context, root, branch):
 
     context['project_slug'] = project_slug
     # create a template branch if necessary
-    if subprocess.run(["git", "rev-parse", "-q", "--verify", branch], cwd=root).returncode != 0:
+    if subprocess.check_call(["git", "rev-parse", "-q", "--verify", branch], cwd=root).returncode != 0:
         firstref = subprocess.run(["git", "rev-list", "--max-parents=0", "--max-count=1", "HEAD"],
                                   cwd=root,
                                   stdout=subprocess.PIPE,
                                   universal_newlines=True).stdout.strip()
-        subprocess.run(["git", "branch", branch, firstref])
+        subprocess.check_call(["git", "branch", branch, firstref])
 
     with TemporaryWorkdir(tmp_workdir, repo=root, branch=branch):
         # update the template
@@ -58,8 +58,8 @@ def update_template(context, root, branch):
                      output_dir=tmpdir)
 
         # commit to template branch
-        subprocess.run(["git", "add", "-A", "."], cwd=tmp_workdir)
-        subprocess.run(["git", "commit", "-nm", "Update template"],
+        subprocess.check_call(["git", "add", "-A", "."], cwd=tmp_workdir)
+        subprocess.check_call(["git", "commit", "-nm", "Update template"],
                        cwd=tmp_workdir)
 
 def main():


### PR DESCRIPTION
- While trying to add cupper to our boilerplate, I ran into the breaking issue that cupper won't finish its routine when the repo in question has pre-commit hooks configured. These hooks would fix e.g. some line endings, nothing the dev couldn't take care of in the cupper-based PR.
- Also noticed that (due to above error), the script continues (returns 0) even though it actually failed. replacing with `subprocess.check_call` fixes that.